### PR TITLE
Update version file

### DIFF
--- a/RSSVE/RSSVE.version
+++ b/RSSVE/RSSVE.version
@@ -12,20 +12,12 @@
     "VERSION" :
     {
         "MAJOR" : 1,
-        "MINOR" : 5,
-        "PATCH" : 0,
-        "BUILD" : 1
+        "MINOR" : 2,
+        "PATCH" : 3
     },
     "KSP_VERSION_MIN" :
     {
         "MAJOR" : 1,
-        "MINOR" : 4,
-        "PATCH" : 0
-    },
-    "KSP_VERSION_MAX" :
-    {
-        "MAJOR" : 1,
-        "MINOR" : 7,
-        "PATCH" : 3
+        "MINOR" : 10
     }
 }

--- a/RSSVE/RSSVE.version
+++ b/RSSVE/RSSVE.version
@@ -11,8 +11,8 @@
     },
     "VERSION" :
     {
-        "MAJOR" : 1,
-        "MINOR" : 2,
+        "MAJOR" : 2,
+        "MINOR" : 1,
         "PATCH" : 3
     },
     "KSP_VERSION_MIN" :


### PR DESCRIPTION
Hi @Theysen,

The latest RSSVE release includes a version file, but it's extremely out of date; it says it's for KSP 1.4.0–1.7.3.
This pull request updates it to say KSP 1.10+ as I suspect is intended from the release description.

Noticed while working on KSP-CKAN/NetKAN#8595.