### PR TITLE
Don't save settings outside game folder

### DIFF
--- a/Source/Settings.cs
+++ b/Source/Settings.cs
@@ -134,14 +134,14 @@ namespace RSSVE
 
                 //  Assemble the path where the configuration file resides.
 
-                string RSSVEConfigFilename = Constants.ConfigurationFilePath + Path.AltDirectorySeparatorChar +
+                string RSSVEConfigFilename = KSPUtil.ApplicationRootPath + Constants.ConfigurationFilePath + Path.AltDirectorySeparatorChar +
                                              Constants.ConfigurationFileName;
 
                 //  Create a new configuration file directory.
 
-                if (!Directory.Exists(Constants.ConfigurationFilePath))
+                if (!Directory.Exists(KSPUtil.ApplicationRootPath + Constants.ConfigurationFilePath))
                 {
-                    Directory.CreateDirectory(Constants.ConfigurationFilePath);
+                    Directory.CreateDirectory(KSPUtil.ApplicationRootPath + Constants.ConfigurationFilePath);
                 }
 
                 //  Create a new empty configuration file.


### PR DESCRIPTION
Hi @Theysen and @NathanKell,

A user spotted an "orphaned GameData" folder containing some of this mod's settings (and PatchManager's settings, see linuxgurugamer/PatchManager#10) after running the game:

- https://forum.kerbalspaceprogram.com/index.php?/topic/209890-rp-1-on-linux-mint-21-cant-enter-space-centre-buildings-so-i-cant-start-a-game-solved/&do=findComment&comment=4179073

![image](https://user-images.githubusercontent.com/1559108/192303493-b4605231-854e-4587-8608-394d6d586577.png)

This happens because `Constants.ConfigurationFilePath` is a relative path, and a few of the places that use it do not prepend the game path (though some other spots do).

Now all places that use this variable prepend the game path, so these files and folders should save to the right folder.
